### PR TITLE
Add CSV-MCP example loader

### DIFF
--- a/csv_mcp/README.md
+++ b/csv_mcp/README.md
@@ -1,0 +1,1 @@
+# CSV-MCP Example

--- a/csv_mcp/csv_loader.py
+++ b/csv_mcp/csv_loader.py
@@ -1,0 +1,11 @@
+import pandas as pd  # type: ignore
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    """Load a CSV file into a DataFrame."""
+    return pd.read_csv(path)
+
+
+def preview_df(df: pd.DataFrame) -> str:
+    """Return first 5 rows of DataFrame as Markdown."""
+    return str(df.head().to_markdown(index=False))

--- a/csv_mcp/input.csv
+++ b/csv_mcp/input.csv
@@ -1,0 +1,4 @@
+name,age,city
+Alice,30,New York
+Bob,25,San Francisco
+Charlie,35,Chicago

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -1,0 +1,15 @@
+from csv_mcp.csv_loader import load_csv, preview_df
+
+
+def test_load_csv_and_preview(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n")
+
+    df = load_csv(csv_path)
+
+    assert list(df.columns) == ["a", "b"]
+    assert df.shape == (2, 2)
+
+    preview = preview_df(df)
+    assert "| a" in preview
+    assert "| 3" in preview


### PR DESCRIPTION
### Summary
- add placeholder README for CSV-MCP example
- provide sample `input.csv`
- implement `load_csv` and `preview_df`
- simple tests for the loader

### Test plan
- `ruff format csv_mcp/csv_loader.py tests/test_csv_loader.py`
- `ruff check csv_mcp/csv_loader.py tests/test_csv_loader.py`
- `mypy csv_mcp`
- ❌ `make tests` *(fails: could not fetch pytest-mock)*

### Issue number

None

### Checks
- [x] I've added new tests
- [x] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass