### PR TITLE
Add retry_with_fallbacks utility

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -16,6 +16,7 @@ from .exceptions import (
     OutputGuardrailTripwireTriggered,
     UserError,
 )
+from .fallback import retry_with_fallbacks
 from .guardrail import (
     GuardrailFunctionOutput,
     InputGuardrail,
@@ -249,5 +250,6 @@ __all__ = [
     "gen_trace_id",
     "gen_span_id",
     "default_tool_error_function",
+    "retry_with_fallbacks",
     "__version__",
 ]

--- a/src/agents/fallback.py
+++ b/src/agents/fallback.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from typing import Any, Callable
+
+DEFAULT_BASE_DELAY = 1.0
+MAX_DELAY = 30.0
+
+
+def _extract_result_conf(value: Any) -> tuple[Any, float]:
+    """Return the result and confidence from ``value``.
+
+    The callable passed to :func:`retry_with_fallbacks` can return either a
+    tuple ``(result, confidence)`` or an object with a ``confidence``
+    attribute. This helper normalizes the return value into a tuple.
+    """
+    if isinstance(value, tuple) and len(value) == 2:
+        return value
+
+    confidence = 0.0
+    if hasattr(value, "confidence"):
+        try:
+            confidence = float(value.confidence)
+        except (TypeError, ValueError):
+            confidence = 0.0
+    return value, confidence
+
+
+def retry_with_fallbacks(
+    agent_call: Callable[[Any], Any],
+    model_chain: Sequence[Any],
+    conf_threshold: float,
+) -> Any:
+    """Run ``agent_call`` across fallback models until the confidence threshold is met.
+
+    ``agent_call`` is called with each model from ``model_chain`` in order. The
+    callable should return either ``(result, confidence)`` or an object with a
+    ``confidence`` attribute. If the returned confidence is greater than or equal
+    to ``conf_threshold`` the result is returned immediately. Between failed
+    attempts the function sleeps using exponential backoff.
+
+    Args:
+        agent_call: Callable invoked with the current model.
+        model_chain: Sequence of models to try in order.
+        conf_threshold: Minimum confidence required to succeed.
+
+    Returns:
+        The result from the first successful call.
+
+    Raises:
+        RuntimeError: If no call meets the confidence threshold.
+    """
+
+    delay = DEFAULT_BASE_DELAY
+    for model in model_chain:
+        try:
+            result, confidence = _extract_result_conf(agent_call(model))
+            if confidence >= conf_threshold:
+                return result
+        except Exception:
+            pass
+        time.sleep(delay)
+        delay = min(delay * 2.0, MAX_DELAY)
+
+    raise RuntimeError("All fallback models failed to meet the confidence threshold.")

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents.fallback import retry_with_fallbacks
+
+
+class DummyResult:
+    def __init__(self, value: Any, confidence: float) -> None:
+        self.value = value
+        self.confidence = confidence
+
+
+def test_retry_with_fallbacks_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    sleeps: list[float] = []
+
+    def agent_call(model: str) -> DummyResult:
+        calls.append(model)
+        if model == "b":
+            return DummyResult("ok", 0.9)
+        return DummyResult("fail", 0.1)
+
+    monkeypatch.setattr("agents.fallback.time.sleep", lambda x: sleeps.append(x))
+
+    result = retry_with_fallbacks(agent_call, ["a", "b"], 0.8)
+
+    assert result.value == "ok"
+    assert calls == ["a", "b"]
+    assert sleeps == [1.0]
+
+
+def test_retry_with_fallbacks_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    def agent_call(model: str) -> DummyResult:
+        return DummyResult("bad", 0.1)
+
+    monkeypatch.setattr("agents.fallback.time.sleep", lambda x: sleeps.append(x))
+
+    with pytest.raises(RuntimeError):
+        retry_with_fallbacks(agent_call, ["a", "b", "c"], 0.8)
+
+    assert sleeps == [1.0, 2.0, 4.0]


### PR DESCRIPTION
## Summary
- implement `retry_with_fallbacks` with exponential backoff
- expose the helper in the package
- test fallback retry logic

## Test Plan
- `ruff format src/agents/fallback.py tests/test_fallback.py src/agents/__init__.py`
- `ruff check src/agents/fallback.py tests/test_fallback.py src/agents/__init__.py`
- `mypy src/agents/fallback.py tests/test_fallback.py --ignore-missing-imports` *(fails: missing stubs in other modules)*
- `pytest tests/test_fallback.py` *(fails: pytest not installed)*
