### PR TITLE
Add orchestrator sample

### DIFF
--- a/csv_loader.py
+++ b/csv_loader.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class DataFrame:
+    rows: list[dict[str, Any]]
+
+
+def load_csv(path: str) -> DataFrame:
+    """Load a CSV file into a simple DataFrame wrapper."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    return DataFrame(rows)
+
+
+def write_csv(df: DataFrame, path: str) -> None:
+    """Write a DataFrame to a CSV file."""
+    if not df.rows:
+        with open(path, "w", newline=""):
+            return
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=df.rows[0].keys())
+        writer.writeheader()
+        writer.writerows(df.rows)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from agents import (
+    Runner,
+    build_aggregator_agent,
+    build_analysis_agent,
+    build_qna_agent,
+    build_transform_agent,
+)
+from csv_loader import DataFrame, load_csv, write_csv
+
+
+async def main() -> None:
+    """Run the orchestration workflow."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_path", help="Path to the CSV file to load.")
+    parser.add_argument("--models", nargs="*", help="Optional list of model names.")
+    args = parser.parse_args()
+
+    data: DataFrame = load_csv(args.input_path)
+
+    analysis_agent = build_analysis_agent(models=args.models)
+    transform_agent = build_transform_agent(models=args.models)
+    qna_agent = build_qna_agent(models=args.models)
+    aggregator_agent = build_aggregator_agent(models=args.models)
+
+    analysis_res, transform_res = await asyncio.gather(
+        Runner.run(analysis_agent, data),
+        Runner.run(transform_agent, data),
+    )
+
+    qna_input = {
+        "analysis": analysis_res.final_output,
+        "transform": transform_res.final_output,
+    }
+    qna_res = await Runner.run(qna_agent, qna_input)
+
+    agg_input = {
+        "analysis": analysis_res.final_output,
+        "transform": transform_res.final_output,
+        "qna": qna_res.final_output,
+    }
+    agg_res = await Runner.run(aggregator_agent, agg_input)
+
+    cleaned_df = agg_res.final_output.get("dataframe")
+    insights = agg_res.final_output.get("insights")
+
+    if cleaned_df is not None:
+        write_csv(cleaned_df, "output.csv")
+    if insights is not None:
+        with open("insights.md", "w") as f:
+            f.write(str(insights))
+
+    print("output.csv")
+    print("insights.md")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -7,6 +7,12 @@ from openai import AsyncOpenAI
 from . import _config
 from .agent import Agent, ToolsToFinalOutputFunction, ToolsToFinalOutputResult
 from .agent_output import AgentOutputSchema, AgentOutputSchemaBase
+from .build import (
+    build_aggregator_agent,
+    build_analysis_agent,
+    build_qna_agent,
+    build_transform_agent,
+)
 from .computer import AsyncComputer, Button, Computer, Environment
 from .exceptions import (
     AgentsException,
@@ -249,5 +255,9 @@ __all__ = [
     "gen_trace_id",
     "gen_span_id",
     "default_tool_error_function",
+    "build_analysis_agent",
+    "build_transform_agent",
+    "build_qna_agent",
+    "build_aggregator_agent",
     "__version__",
 ]

--- a/src/agents/build.py
+++ b/src/agents/build.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from .agent import Agent
+
+
+def build_analysis_agent(models: list[str] | None = None) -> Agent:
+    """Return an agent that performs data analysis."""
+    model = models[0] if models else None
+    return Agent(name="analysis_agent", instructions="Analyze the provided data.", model=model)
+
+
+def build_transform_agent(models: list[str] | None = None) -> Agent:
+    """Return an agent that transforms data."""
+    model = models[1] if models and len(models) > 1 else (models[0] if models else None)
+    return Agent(name="transform_agent", instructions="Transform the provided data.", model=model)
+
+
+def build_qna_agent(models: list[str] | None = None) -> Agent:
+    """Return an agent that answers questions about the data."""
+    model = models[2] if models and len(models) > 2 else (models[0] if models else None)
+    return Agent(name="qna_agent", instructions="Answer questions about the data.", model=model)
+
+
+def build_aggregator_agent(models: list[str] | None = None) -> Agent:
+    """Return an agent that aggregates all insights."""
+    model = models[3] if models and len(models) > 3 else (models[0] if models else None)
+    return Agent(name="aggregator_agent", instructions="Aggregate all insights.", model=model)


### PR DESCRIPTION
## Summary
- implement `orchestrator.py` for running multiple agents
- add tiny `csv_loader` helper module
- provide simple agent builders in `src/agents/build.py`
- export builder helpers from `agents.__init__`

## Test Plan
- `make format`
- `make lint`
- `make mypy` *(fails: Cannot find implementation or library stubs)*
- `make tests` *(fails: pytest not installed)*
