### PR TITLE
Add CSV fixtures and agent tests

### DIFF
--- a/tests/fixtures/sample.csv
+++ b/tests/fixtures/sample.csv
@@ -1,0 +1,4 @@
+name,age,city
+Alice,30,New York
+Bob,25,San Francisco
+Charlie,35,Chicago

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+
+import pytest
+
+from agents import Runner
+from agents.build import (
+    build_analysis_agent,
+    build_transform_agent,
+    build_qna_agent,
+    build_aggregator_agent,
+)
+from tests.fake_model import FakeModel
+from tests.test_responses import get_text_message, get_final_output_message
+from csv_loader import DataFrame
+
+
+@pytest.mark.asyncio
+async def test_agents_pipeline():
+    data = DataFrame(rows=[{"a": 1}, {"a": 2}, {"a": 3}])
+
+    analysis_agent = build_analysis_agent()
+    transform_agent = build_transform_agent()
+    qna_agent = build_qna_agent()
+    aggregator_agent = build_aggregator_agent()
+
+    analysis_agent.model = FakeModel()
+    analysis_agent.model.set_next_output([get_text_message("analysis")])
+    transform_agent.model = FakeModel()
+    transform_agent.model.set_next_output([get_text_message("transform")])
+    qna_agent.model = FakeModel()
+    qna_agent.model.set_next_output([get_text_message("answer")])
+    aggregator_agent.model = FakeModel()
+    aggregator_agent.output_type = dict
+    payload = json.dumps({"dataframe": {"rows": []}, "insights": "hi"})
+    aggregator_agent.model.set_next_output([get_final_output_message(payload)])
+
+    analysis_res, transform_res = await asyncio.gather(
+        Runner.run(analysis_agent, data),
+        Runner.run(transform_agent, data),
+    )
+
+    qna_input = {
+        "analysis": analysis_res.final_output,
+        "transform": transform_res.final_output,
+    }
+    qna_res = await Runner.run(qna_agent, qna_input)
+
+    agg_input = {
+        "analysis": analysis_res.final_output,
+        "transform": transform_res.final_output,
+        "qna": qna_res.final_output,
+    }
+    agg_res = await Runner.run(aggregator_agent, agg_input)
+
+    assert set(agg_res.final_output.keys()) == {"dataframe", "insights"}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,10 @@
+import pathlib
+
+from csv_loader import load_csv
+
+
+def test_load_csv_shape():
+    path = pathlib.Path(__file__).parent / "fixtures" / "sample.csv"
+    df = load_csv(path)
+    assert len(df.rows) == 3
+    assert len(df.rows[0]) == 3

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,55 @@
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import orchestrator
+from csv_loader import DataFrame
+from agents import Agent, RunContextWrapper, RunResult
+
+
+def _result(output: Any) -> RunResult:
+    return RunResult(
+        input="x",
+        new_items=[],
+        raw_responses=[],
+        final_output=output,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        _last_agent=Agent(name="test"),
+        context_wrapper=RunContextWrapper(context=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_end_to_end(monkeypatch, tmp_path):
+    csv_src = Path("tests/fixtures/sample.csv")
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text(csv_src.read_text())
+    monkeypatch.chdir(tmp_path)
+
+    async def fake_run(cls, agent: Agent, input: Any, **_: Any) -> RunResult:
+        if agent.name == "analysis_agent":
+            return _result("analysis")
+        if agent.name == "transform_agent":
+            return _result("transform")
+        if agent.name == "qna_agent":
+            return _result("answer")
+        if agent.name == "aggregator_agent":
+            return _result({"dataframe": DataFrame(rows=[]), "insights": "insight"})
+        raise AssertionError("unknown agent")
+
+    monkeypatch.setattr(orchestrator.Runner, "run", classmethod(fake_run))
+
+    printed: list[str] = []
+    monkeypatch.setattr(orchestrator, "print", lambda x: printed.append(x))
+
+    monkeypatch.setattr(sys, "argv", ["prog", str(csv_path)])
+    await orchestrator.main()
+
+    assert "output.csv" in printed
+    assert "insights.md" in printed
+    assert Path("output.csv").exists()
+    assert Path("insights.md").exists()


### PR DESCRIPTION
### Summary
- add sample CSV fixture
- test csv loader output size
- mock agent pipeline with FakeModel
- integration test for orchestrator script

### Test plan
- `make format` *(fails: Failed to fetch `textual`)*
- `make lint` *(fails: Failed to fetch `fastapi`)*
- `make mypy` *(fails: Failed to fetch `typing-extensions`)*
- `make tests` *(fails: Failed to fetch `mypy`)*

### Issue number

### Checks
- [x] I've added new tests
- [ ] I've updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass